### PR TITLE
fix: Use named relative selfreference in docker-compose.override.yml,…

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,8 +25,8 @@ services:
   ### nodejs modules
 
   concept-catalogue-gui:
-    build: ./
-    command: npm start
+    #interestingly, if multiple docker-compose files are combined, then "." gets wrong value
+    build: ../concept-catalogue-gui
     ports:
       - "8202:3111"
     volumes:


### PR DESCRIPTION
… because the . is incorrectly resolved when multiple docker-compose files are combined.