### PR TITLE
fix: patchConceptForm with metaDataFieldsToOmit

### DIFF
--- a/src/lib/patchConceptForm.ts
+++ b/src/lib/patchConceptForm.ts
@@ -10,23 +10,23 @@ import {
   conceptPatchIsSavingAction
 } from '../app/reducers/stateReducer';
 
+const metaDataFieldsToOmit = [
+  'endringslogelement',
+  'ansvarligVirksomhet',
+  'revisjonAvSistPublisert',
+  'erSistPublisert',
+  'originaltBegrep',
+  'id',
+  'revisjonAv'
+];
+
 export const patchConceptFromForm = (
   values,
   { concept, dispatch, lastPatchedResponse = {}, isSaving }
 ): void => {
   const diff = compare(
-    omit(lastPatchedResponse, [
-      'endringslogelement',
-      'ansvarligVirksomhet',
-      'status',
-      'revisjonAvSistPublisert',
-      'erSistPublisert',
-      'versjonsnr',
-      'originaltBegrep',
-      'id',
-      'revisjonAv'
-    ]),
-    values
+    omit(lastPatchedResponse, metaDataFieldsToOmit),
+    omit({ ...lastPatchedResponse, ...values }, metaDataFieldsToOmit)
   );
   if (!isSaving && diff.length > 0) {
     const conceptId = _.get(concept, 'id');


### PR DESCRIPTION
1) Ved publisering må BE ha status og version fra FE -> "status" og "version" må ikke være med i "metaDataFieldsToOmit".

2) Ved diff:
"values" inneholder kun felt fra skjema som er endret (dirty), så diff kan ikke bare sammenligne lastPatchedResponse (hele begrepet) og values, den må sammenligne lastPatchedResponse og { ...lastPatchedResponse, ...values } slik at man samtidig beholder alle andre felt som ikke er dirty.